### PR TITLE
Bugfix: skip users that the client is unable to find

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -65,13 +65,14 @@ func New(cfg *config.Config, a aws.Client, g google.Client, ids identitystoreifa
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-users
 // query possible values:
-// '' --> empty or not defined
-//  name:'Jane'
-//  email:admin*
-//  isAdmin=true
-//  manager='janesmith@example.com'
-//  orgName=Engineering orgTitle:Manager
-//  EmploymentData.projects:'GeneGnomes'
+// ” --> empty or not defined
+//
+//	name:'Jane'
+//	email:admin*
+//	isAdmin=true
+//	manager='janesmith@example.com'
+//	orgName=Engineering orgTitle:Manager
+//	EmploymentData.projects:'GeneGnomes'
 func (s *syncGSuite) SyncUsers(query string) error {
 	log.Debug("get deleted users")
 	deletedUsers, err := s.google.GetDeletedUsers()
@@ -164,13 +165,14 @@ func (s *syncGSuite) SyncUsers(query string) error {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
 // query possible values:
-// '' --> empty or not defined
-//  name='contact'
-//  email:admin*
-//  memberKey=user@company.com
-//  name:contact* email:contact*
-//  name:Admin* email:aws-*
-//  email:aws-*
+// ” --> empty or not defined
+//
+//	name='contact'
+//	email:admin*
+//	memberKey=user@company.com
+//	name:contact* email:contact*
+//	name:Admin* email:aws-*
+//	email:aws-*
 func (s *syncGSuite) SyncGroups(query string) error {
 
 	log.WithField("query", query).Debug("get google groups")
@@ -270,20 +272,22 @@ func (s *syncGSuite) SyncGroups(query string) error {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
 // query possible values:
-// '' --> empty or not defined
-//  name='contact'
-//  email:admin*
-//  memberKey=user@company.com
-//  name:contact* email:contact*
-//  name:Admin* email:aws-*
-//  email:aws-*
+// ” --> empty or not defined
+//
+//	name='contact'
+//	email:admin*
+//	memberKey=user@company.com
+//	name:contact* email:contact*
+//	name:Admin* email:aws-*
+//	email:aws-*
+//
 // process workflow:
-//  1) delete users in aws, these were deleted in google
-//  2) update users in aws, these were updated in google
-//  3) add users in aws, these were added in google
-//  4) add groups in aws and add its members, these were added in google
-//  5) validate equals aws an google groups members
-//  6) delete groups in aws, these were deleted in google
+//  1. delete users in aws, these were deleted in google
+//  2. update users in aws, these were updated in google
+//  3. add users in aws, these were added in google
+//  4. add groups in aws and add its members, these were added in google
+//  5. validate equals aws an google groups members
+//  6. delete groups in aws, these were deleted in google
 func (s *syncGSuite) SyncGroupsUsers(query string) error {
 
 	log.WithField("query", query).Info("get google groups")
@@ -560,6 +564,13 @@ func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*ad
 			u, err := s.google.GetUsers(q) // TODO: implement GetUser(m.Email)
 			if err != nil {
 				return nil, nil, err
+			}
+
+			// In some cases, when requesting users, the Google client will return
+			// an empty slice (no users) but no error.
+			// In that case, we ignore this user and continue.
+			if len(u) == 0 {
+				continue
 			}
 
 			membersUsers = append(membersUsers, u[0])


### PR DESCRIPTION
This PR adds a bugfix that prevents a panic being raised if the google client fails to return any `admin.User`.

All unit tests pass.

```bash
$ go test -v ./...
?   	github.com/awslabs/ssosync	[no test files]
?   	github.com/awslabs/ssosync/cmd	[no test files]
=== RUN   Test_getGroupOperations
=== RUN   Test_getGroupOperations/equal_groups_google_and_aws
=== RUN   Test_getGroupOperations/add_two_new_aws_groups
=== RUN   Test_getGroupOperations/delete_two_aws_groups
=== RUN   Test_getGroupOperations/add_one,_delete_one_and_one_equal
--- PASS: Test_getGroupOperations (0.00s)
    --- PASS: Test_getGroupOperations/equal_groups_google_and_aws (0.00s)
    --- PASS: Test_getGroupOperations/add_two_new_aws_groups (0.00s)
    --- PASS: Test_getGroupOperations/delete_two_aws_groups (0.00s)
    --- PASS: Test_getGroupOperations/add_one,_delete_one_and_one_equal (0.00s)
=== RUN   Test_getUserOperations
=== RUN   Test_getUserOperations/equal_user_google_and_aws
=== RUN   Test_getUserOperations/add_two_new_aws_users
=== RUN   Test_getUserOperations/delete_two_aws_users
=== RUN   Test_getUserOperations/add_on,_delete_one,_update_one_and_one_equal
--- PASS: Test_getUserOperations (0.00s)
    --- PASS: Test_getUserOperations/equal_user_google_and_aws (0.00s)
    --- PASS: Test_getUserOperations/add_two_new_aws_users (0.00s)
    --- PASS: Test_getUserOperations/delete_two_aws_users (0.00s)
    --- PASS: Test_getUserOperations/add_on,_delete_one,_update_one_and_one_equal (0.00s)
=== RUN   Test_getGroupUsersOperations
=== RUN   Test_getGroupUsersOperations/one_add,_one_delete,_one_equal
--- PASS: Test_getGroupUsersOperations (0.00s)
    --- PASS: Test_getGroupUsersOperations/one_add,_one_delete,_one_equal (0.00s)
=== RUN   Test_GetGroupsWithoutPagination
--- PASS: Test_GetGroupsWithoutPagination (0.00s)
=== RUN   Test_GetGroupsWithPagination
--- PASS: Test_GetGroupsWithPagination (0.00s)
=== RUN   Test_GetGroupsEmptyResponse
--- PASS: Test_GetGroupsEmptyResponse (0.00s)
=== RUN   Test_GetGroupsErrorResponse
--- PASS: Test_GetGroupsErrorResponse (0.00s)
=== RUN   Test_GetUsersWithoutPagination
--- PASS: Test_GetUsersWithoutPagination (0.00s)
=== RUN   Test_GetUsersWithPagination
--- PASS: Test_GetUsersWithPagination (0.00s)
=== RUN   Test_GetUsersEmptyResponse
--- PASS: Test_GetUsersEmptyResponse (0.00s)
=== RUN   Test_GetUsersErrorResponse
--- PASS: Test_GetUsersErrorResponse (0.00s)
=== RUN   Test_ConvertSdkUserObjToNative
--- PASS: Test_ConvertSdkUserObjToNative (0.00s)
=== RUN   Test_CreateUserIDtoUserObjMap
--- PASS: Test_CreateUserIDtoUserObjMap (0.00s)
=== RUN   Test_GetGroupMembershipsLists
--- PASS: Test_GetGroupMembershipsLists (0.00s)
=== RUN   Test_IsUserInGroup
--- PASS: Test_IsUserInGroup (0.00s)
=== RUN   Test_RemoveUserFromGroup
--- PASS: Test_RemoveUserFromGroup (0.00s)
PASS
ok  	github.com/awslabs/ssosync/internal	(cached)
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestSendRequestBadUrl
--- PASS: TestSendRequestBadUrl (0.00s)
=== RUN   TestSendRequestBadStatusCode
--- PASS: TestSendRequestBadStatusCode (0.00s)
=== RUN   TestSendRequestCheckAuthHeader
--- PASS: TestSendRequestCheckAuthHeader (0.00s)
=== RUN   TestSendRequestWithBodyCheckHeaders
--- PASS: TestSendRequestWithBodyCheckHeaders (0.00s)
=== RUN   TestClient_FindUserByEmail
--- PASS: TestClient_FindUserByEmail (0.00s)
=== RUN   TestClient_FindGroupByDisplayName
--- PASS: TestClient_FindGroupByDisplayName (0.00s)
=== RUN   TestClient_CreateUser
--- PASS: TestClient_CreateUser (0.00s)
=== RUN   TestClient_UpdateUser
--- PASS: TestClient_UpdateUser (0.00s)
=== RUN   TestNewGroup
--- PASS: TestNewGroup (0.00s)
=== RUN   TestNewUser
--- PASS: TestNewUser (0.00s)
=== RUN   TestUpdateUser
--- PASS: TestUpdateUser (0.00s)
PASS
ok  	github.com/awslabs/ssosync/internal/aws	(cached)
?   	github.com/awslabs/ssosync/internal/aws/mock	[no test files]
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
PASS
ok  	github.com/awslabs/ssosync/internal/config	(cached)
?   	github.com/awslabs/ssosync/internal/google	[no test files]
?   	github.com/awslabs/ssosync/internal/mocks	[no test files]
```