### PR TITLE
Remove trailing newlines added by sops when handling secrets

### DIFF
--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/base64"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
@@ -71,6 +72,9 @@ func (s *Secrets) getSecret(secretKey string) (string, error) {
 		}
 		secretString = string(decodedBinarySecretBytes[:l])
 	}
+
+	// Remove trailing new lines added by sops
+	secretString = strings.TrimRight(secretString, "\n")
 
 	return secretString, nil
 }


### PR DESCRIPTION
This PR removes trailing newlines from values retrieved from AWS secrets manager.

All tests pass:

```bash
$ go test -v ./...
?   	github.com/awslabs/ssosync	[no test files]
?   	github.com/awslabs/ssosync/cmd	[no test files]
=== RUN   Test_getGroupOperations
=== RUN   Test_getGroupOperations/equal_groups_google_and_aws
=== RUN   Test_getGroupOperations/add_two_new_aws_groups
=== RUN   Test_getGroupOperations/delete_two_aws_groups
=== RUN   Test_getGroupOperations/add_one,_delete_one_and_one_equal
--- PASS: Test_getGroupOperations (0.00s)
    --- PASS: Test_getGroupOperations/equal_groups_google_and_aws (0.00s)
    --- PASS: Test_getGroupOperations/add_two_new_aws_groups (0.00s)
    --- PASS: Test_getGroupOperations/delete_two_aws_groups (0.00s)
    --- PASS: Test_getGroupOperations/add_one,_delete_one_and_one_equal (0.00s)
=== RUN   Test_getUserOperations
=== RUN   Test_getUserOperations/equal_user_google_and_aws
=== RUN   Test_getUserOperations/add_two_new_aws_users
=== RUN   Test_getUserOperations/delete_two_aws_users
=== RUN   Test_getUserOperations/add_on,_delete_one,_update_one_and_one_equal
--- PASS: Test_getUserOperations (0.00s)
    --- PASS: Test_getUserOperations/equal_user_google_and_aws (0.00s)
    --- PASS: Test_getUserOperations/add_two_new_aws_users (0.00s)
    --- PASS: Test_getUserOperations/delete_two_aws_users (0.00s)
    --- PASS: Test_getUserOperations/add_on,_delete_one,_update_one_and_one_equal (0.00s)
=== RUN   Test_getGroupUsersOperations
=== RUN   Test_getGroupUsersOperations/one_add,_one_delete,_one_equal
--- PASS: Test_getGroupUsersOperations (0.00s)
    --- PASS: Test_getGroupUsersOperations/one_add,_one_delete,_one_equal (0.00s)
=== RUN   Test_GetGroupsWithoutPagination
--- PASS: Test_GetGroupsWithoutPagination (0.00s)
=== RUN   Test_GetGroupsWithPagination
--- PASS: Test_GetGroupsWithPagination (0.00s)
=== RUN   Test_GetGroupsEmptyResponse
--- PASS: Test_GetGroupsEmptyResponse (0.00s)
=== RUN   Test_GetGroupsErrorResponse
--- PASS: Test_GetGroupsErrorResponse (0.00s)
=== RUN   Test_GetUsersWithoutPagination
--- PASS: Test_GetUsersWithoutPagination (0.00s)
=== RUN   Test_GetUsersWithPagination
--- PASS: Test_GetUsersWithPagination (0.00s)
=== RUN   Test_GetUsersEmptyResponse
--- PASS: Test_GetUsersEmptyResponse (0.00s)
=== RUN   Test_GetUsersErrorResponse
--- PASS: Test_GetUsersErrorResponse (0.00s)
=== RUN   Test_ConvertSdkUserObjToNative
--- PASS: Test_ConvertSdkUserObjToNative (0.00s)
=== RUN   Test_CreateUserIDtoUserObjMap
--- PASS: Test_CreateUserIDtoUserObjMap (0.00s)
=== RUN   Test_GetGroupMembershipsLists
--- PASS: Test_GetGroupMembershipsLists (0.00s)
=== RUN   Test_IsUserInGroup
--- PASS: Test_IsUserInGroup (0.00s)
=== RUN   Test_RemoveUserFromGroup
--- PASS: Test_RemoveUserFromGroup (0.00s)
PASS
ok  	github.com/awslabs/ssosync/internal	(cached)
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestSendRequestBadUrl
--- PASS: TestSendRequestBadUrl (0.00s)
=== RUN   TestSendRequestBadStatusCode
--- PASS: TestSendRequestBadStatusCode (0.00s)
=== RUN   TestSendRequestCheckAuthHeader
--- PASS: TestSendRequestCheckAuthHeader (0.00s)
=== RUN   TestSendRequestWithBodyCheckHeaders
--- PASS: TestSendRequestWithBodyCheckHeaders (0.00s)
=== RUN   TestClient_FindUserByEmail
--- PASS: TestClient_FindUserByEmail (0.00s)
=== RUN   TestClient_FindGroupByDisplayName
--- PASS: TestClient_FindGroupByDisplayName (0.00s)
=== RUN   TestClient_CreateUser
--- PASS: TestClient_CreateUser (0.00s)
=== RUN   TestClient_UpdateUser
--- PASS: TestClient_UpdateUser (0.00s)
=== RUN   TestNewGroup
--- PASS: TestNewGroup (0.00s)
=== RUN   TestNewUser
--- PASS: TestNewUser (0.00s)
=== RUN   TestUpdateUser
--- PASS: TestUpdateUser (0.00s)
PASS
ok  	github.com/awslabs/ssosync/internal/aws	(cached)
?   	github.com/awslabs/ssosync/internal/aws/mock	[no test files]
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
PASS
ok  	github.com/awslabs/ssosync/internal/config	(cached)
?   	github.com/awslabs/ssosync/internal/google	[no test files]
?   	github.com/awslabs/ssosync/internal/mocks	[no test files]
```